### PR TITLE
Fix CSS generation in production builds

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -275,9 +275,6 @@ npm run build:css
 
 # Build entire site
 npm run build
-
-# Production build (optimized)
-npm run build:prod
 ```
 
 ### File Watching & Hot Reload
@@ -292,7 +289,7 @@ npm run build:prod
 3. **Update data**: Edit JSON files in `src/_data/`
 4. **Add styles**: Use Tailwind classes or add to component CSS files
 5. **Test responsive**: Use browser dev tools to test breakpoints
-6. **Build for production**: `npm run build:prod`
+6. **Build for production**: `npm run build`
 
 ---
 
@@ -408,7 +405,7 @@ gsap.to(element, { duration: 0.3, opacity: 1 });
 ### Development Quality Checks
 ```bash
 # Build production version
-npm run build:prod
+npm run build
 
 # Check for console errors in browser
 # Verify responsive breakpoints
@@ -479,7 +476,7 @@ npm run dev
 # → Include in src/index.njk
 
 # Build for production
-npm run build:prod
+npm run build
 ```
 
 ### Design Token Quick Reference

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ npm run dev              # Build CSS + start dev server with hot reload
 ### Build Commands
 ```bash
 npm run build:css       # Build Tailwind CSS only
-npm run build           # Build static site with Eleventy
-npm run build:prod      # Build optimized production version
+npm run build           # Build Tailwind CSS and static site (production)
 npm start              # Alias for npm run dev
 ```
 
@@ -213,8 +212,10 @@ lg: '1440px'             /* Desktop */
 
 ### Production Build
 ```bash
-npm run build:prod       # Builds optimized CSS + static site
+npm run build            # Builds CSS and static site for deployment
 ```
+
+When deploying to platforms like Cloudflare Pages, configure the build command as `npm run build` and set the output directory to `_site` so the generated CSS is served correctly.
 
 ### Build Output
 - Generated files go to `_site/` directory

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Tucker Wieland's professional portfolio website",
   "main": "index.js",
   "scripts": {
-    "build": "eleventy",
+    "build": "npm run build:css && eleventy",
     "build:css": "tailwindcss -i ./src/css/main.css -o ./_site/css/main.css",
-    "build:prod": "npm run build:css && eleventy",
     "dev": "npm run build:css && eleventy --serve --watch",
     "start": "npm run dev"
   },


### PR DESCRIPTION
## Summary
- build Tailwind CSS before running Eleventy during production builds
- document new `npm run build` command and Cloudflare Pages setup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e7cc640832e85e8936eb770e4fe