### PR TITLE
feat: replace company names with logos in project showcase and modal

### DIFF
--- a/src/_data/tokens.json
+++ b/src/_data/tokens.json
@@ -245,6 +245,36 @@
       "colors": ["#629fde", "#f1c40f", "#27ae60", "#e74c3c", "#f45cb3", "#f87c46"]
     }
   },
+  "companyLogos": {
+    "JUSTWORKS": {
+      "src": "static/company-logos/Justworks Logo.svg",
+      "alt": "Justworks Logo",
+      "mobileClasses": "h-4 w-auto object-contain max-w-20",
+      "tabletClasses": "h-5 w-auto object-contain max-w-28",
+      "desktopClasses": "h-6 w-auto object-contain max-w-32"
+    },
+    "SHOPIFY": {
+      "src": "static/company-logos/Shopify Logo.svg", 
+      "alt": "Shopify Logo",
+      "mobileClasses": "h-4 w-auto object-contain max-w-20",
+      "tabletClasses": "h-5 w-auto object-contain max-w-28",
+      "desktopClasses": "h-6 w-auto object-contain max-w-32"
+    },
+    "GENERAL ASSEMBLY": {
+      "src": "static/company-logos/GA logo.svg",
+      "alt": "General Assembly Logo",
+      "mobileClasses": "h-4 w-auto object-contain max-w-20",
+      "tabletClasses": "h-5 w-auto object-contain max-w-28",
+      "desktopClasses": "h-6 w-auto object-contain max-w-32"
+    },
+    "BILLION OYSTER PROJECT": {
+      "src": "static/company-logos/BOP Logo.svg",
+      "alt": "Billion Oyster Project Logo",
+      "mobileClasses": "h-6 w-auto object-contain max-w-20",
+      "tabletClasses": "h-8 w-auto object-contain max-w-28",
+      "desktopClasses": "h-10 w-auto object-contain max-w-32"
+    }
+  },
   "accessibility": {
     "contrastRatios": {
       "primaryText": "15.6:1",

--- a/src/_includes/components/project-table.njk
+++ b/src/_includes/components/project-table.njk
@@ -24,7 +24,15 @@
                 <!-- Mobile Layout (below 360px) -->
                 <div class="block xs:hidden">
                     <div class="flex">
-                        <div class="w-24 font-mono text-[14px] text-text-primary font-semibold">{{ project.company }}</div>
+                        <div class="w-24 flex items-center justify-center">
+                            {% if tokens.companyLogos[project.company] %}
+                                <img src="{{ tokens.companyLogos[project.company].src }}" 
+                                     alt="{{ tokens.companyLogos[project.company].alt }}"
+                                     class="{{ tokens.companyLogos[project.company].mobileClasses }}">
+                            {% else %}
+                                <div class="font-mono text-[14px] text-text-primary font-semibold">{{ project.company }}</div>
+                            {% endif %}
+                        </div>
                         <div class="flex-1 font-mono text-[16px] text-text-primary leading-relaxed">
                             {{ project.description }}
                         </div>
@@ -41,7 +49,15 @@
                 <div class="hidden xs:block md:hidden">
                     <div class="mb-4">
                         <div class="flex items-center space-x-8">
-                            <div class="font-mono text-[16px] text-text-primary font-semibold">{{ project.company }}</div>
+                            {% if tokens.companyLogos[project.company] %}
+                                <div class="flex items-center justify-center w-32">
+                                    <img src="{{ tokens.companyLogos[project.company].src }}" 
+                                         alt="{{ tokens.companyLogos[project.company].alt }}"
+                                         class="{{ tokens.companyLogos[project.company].tabletClasses }}">
+                                </div>
+                            {% else %}
+                                <div class="font-mono text-[16px] text-text-primary font-semibold">{{ project.company }}</div>
+                            {% endif %}
                             <div class="font-mono text-[18px] text-text-primary leading-relaxed">
                                 {{ project.description }}
                             </div>
@@ -57,7 +73,15 @@
 
                 <!-- Desktop Layout (768px and above) -->
                 <div class="hidden md:flex md:items-center">
-                    <div class="font-mono w-30 text-[16px] text-text-primary font-semibold text-center">{{ project.company }}</div>
+                    {% if tokens.companyLogos[project.company] %}
+                        <div class="w-30 flex items-center justify-center">
+                            <img src="{{ tokens.companyLogos[project.company].src }}" 
+                                 alt="{{ tokens.companyLogos[project.company].alt }}"
+                                 class="{{ tokens.companyLogos[project.company].desktopClasses }}">
+                        </div>
+                    {% else %}
+                        <div class="font-mono w-30 text-[16px] text-text-primary font-semibold text-center">{{ project.company }}</div>
+                    {% endif %}
                     <div class="flex-1 px-11">
                         <div class="font-mono text-[20px] text-text-primary leading-relaxed">
                             {{ project.description }}

--- a/src/js/components/project-modal.js
+++ b/src/js/components/project-modal.js
@@ -1,3 +1,27 @@
+// Company logo mapping - mirrors the tokens.json companyLogos structure
+const companyLogos = {
+    "JUSTWORKS": {
+        src: "static/company-logos/Justworks Logo.svg",
+        alt: "Justworks Logo",
+        modalClasses: "h-10 w-auto object-contain max-w-48"
+    },
+    "SHOPIFY": {
+        src: "static/company-logos/Shopify Logo.svg", 
+        alt: "Shopify Logo",
+        modalClasses: "h-10 w-auto object-contain max-w-48"
+    },
+    "GENERAL ASSEMBLY": {
+        src: "static/company-logos/GA logo.svg",
+        alt: "General Assembly Logo", 
+        modalClasses: "h-10 w-auto object-contain max-w-48"
+    },
+    "BILLION OYSTER PROJECT": {
+        src: "static/company-logos/BOP Logo.svg",
+        alt: "Billion Oyster Project Logo",
+        modalClasses: "h-16 w-auto object-contain max-w-48"
+    }
+};
+
 // Project Modal Component - Handles the modal popup and all its interactions
 const ProjectModal = {
     // Store current project data
@@ -45,9 +69,9 @@ const ProjectModal = {
             <div class="px-2 py-10 md:p-16 flex-1">
                 <!-- Header -->
                 <div class="flex items-center justify-between mb-4 md:mb-16">
-                    <h2 class="text-[24px] sm:text-[32px] md:text-[40px] font-bold font-helvetica uppercase">${project.title}</h2>
-                    <div class="text-right">
-                        <div class="text-sm font-mono">${project.company}</div>
+                    <h2 class="text-[16px] sm:text-[20px] md:text-[24px] font-bold font-helvetica uppercase leading-tight pr-8">${project.title}</h2>
+                    <div class="flex items-center justify-center pl-8 py-4">
+                        ${this.renderCompanyLogo(project.company)}
                     </div>
                 </div>
 
@@ -228,6 +252,16 @@ const ProjectModal = {
                 </div>
             </div>
         `;
+    },
+
+    // Render company logo or fallback to company name
+    renderCompanyLogo(companyName) {
+        const logoConfig = companyLogos[companyName];
+        if (logoConfig) {
+            return `<img src="${logoConfig.src}" alt="${logoConfig.alt}" class="${logoConfig.modalClasses}">`;
+        } else {
+            return `<div class="text-sm font-mono">${companyName}</div>`;
+        }
     },
 
     // Render content section


### PR DESCRIPTION
- Add company logo mapping system in tokens.json with responsive sizing
- Replace company text with logos in project table across all breakpoints
- Update project modal to display company logos instead of text names
- Implement standardized sizing classes for consistent logo display
- Add special sizing adjustments for BOP logo due to different aspect ratio
- Center logos in their allocated space for better visual alignment

Supports: Justworks, Shopify, General Assembly, Billion Oyster Project