### PR TITLE
fix: compile TypeScript in Eleventy build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,10 +19,32 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addWatchTarget("./src/css/");
   eleventyConfig.addWatchTarget("./tailwind.config.js");
   eleventyConfig.addWatchTarget("./postcss.config.js");
+  eleventyConfig.addWatchTarget("./src/js/");
 
   // Don't copy the unprocessed CSS and TypeScript source files into the output
   eleventyConfig.ignores.add("src/css/**/*");
   eleventyConfig.ignores.add("src/js/**/*.ts");
+
+  // Build TypeScript before Eleventy runs
+  eleventyConfig.on("beforeBuild", () => {
+    console.log("Running TypeScript build...");
+    return new Promise((resolve, reject) => {
+      exec("tsc", (error, stdout, stderr) => {
+        if (error) {
+          console.error("TypeScript build error:", stderr);
+          reject(error);
+        } else {
+          console.log(stdout);
+          resolve();
+        }
+      });
+    });
+  });
+
+  // Rebuild TypeScript on watched changes
+  eleventyConfig.on("beforeWatch", () => {
+    exec("tsc");
+  });
 
   // Build Tailwind CSS after Eleventy has written output
   eleventyConfig.on("afterBuild", () => {


### PR DESCRIPTION
## Summary
- compile TypeScript during Eleventy build and watch runs
- watch TypeScript sources for automatic rebuilds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af53a31a30832e8c170ab44af8e561