### PR TITLE
fix: ensure sitemap.xml generates valid XML without leading whitespace

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -42,3 +42,6 @@ Thumbs.db
 *.ttf
 *.otf
 *.eot
+
+# XML files that need precise formatting
+src/sitemap.xml.njk

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -1,19 +1,20 @@
 ---
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
+layout: false
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {%- for page in collections.all %} {%- if not page.data.eleventyExcludeFromCollections and page.url %}
+    {%- for page in collections.all -%} {%- if not page.data.eleventyExcludeFromCollections and page.url -%}
     <url>
         <loc>{{ metadata.site.url }}{{ page.url }}</loc>
-        {%- if page.url == "/" %}
+        {%- if page.url == "/" -%}
         <priority>1.0</priority>
-        {%- else %}
+        {%- else -%}
         <priority>0.8</priority>
-        {%- endif %}
+        {%- endif -%}
         <changefreq>{% if page.url == "/" %}weekly{% else %}monthly{% endif %}</changefreq>
     </url>
-    {%- endif %} {%- endfor %}
+    {%- endif -%} {%- endfor -%}
 </urlset>

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -17,4 +17,3 @@ layout: false
     </url>
     {%- endif -%} {%- endfor -%}
 </urlset>
-4

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -3,7 +3,6 @@ permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 layout: false
 ---
-
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {%- for page in collections.all -%} {%- if not page.data.eleventyExcludeFromCollections and page.url -%}

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -17,3 +17,4 @@ layout: false
     </url>
     {%- endif -%} {%- endfor -%}
 </urlset>
+4


### PR DESCRIPTION
- Add layout: false to prevent base layout wrapping
- Remove blank line between front matter and XML declaration
- Use Nunjucks whitespace-trim markers on control tags
- Maintain existing URL/priority/changefreq logic

This fixes XML parsing issues where bytes appeared before the XML declaration.